### PR TITLE
Fix config tab appearing twice

### DIFF
--- a/src/main/java/me/cortex/nvidium/config/ConfigGuiBuilder.java
+++ b/src/main/java/me/cortex/nvidium/config/ConfigGuiBuilder.java
@@ -23,7 +23,7 @@ import org.embeddedt.embeddium.api.options.structure.OptionPage;
 import java.util.ArrayList;
 import java.util.List;
 
-@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+@EventBusSubscriber(modid = Nvidium.MOD_ID, bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
 public class ConfigGuiBuilder {
     private static final NvidiumConfigStore store = NvidiumConfigStore.INSTANCE;
 

--- a/src/main/java/me/cortex/nvidium/sodiumCompat/IrisCheck.java
+++ b/src/main/java/me/cortex/nvidium/sodiumCompat/IrisCheck.java
@@ -4,7 +4,7 @@ import net.irisshaders.iris.api.v0.IrisApi;
 import net.neoforged.fml.loading.FMLLoader;
 
 public class IrisCheck {
-    public static final boolean IRIS_LOADED = FMLLoader.getLoadingModList().getModFileById("oculus") != null;
+    public static final boolean IRIS_LOADED = FMLLoader.getLoadingModList().getModFileById("iris") != null;
 
     private static boolean checkIrisShaders() {
         return IrisApi.getInstance().isShaderPackInUse();


### PR DESCRIPTION
Previously, the `EventBusSubscriber` was registered for both the `acedium` and `nvidium` mods.